### PR TITLE
Support PCI vendor-id filtering for --pci option

### DIFF
--- a/libnw/libnw.c
+++ b/libnw/libnw.c
@@ -178,7 +178,7 @@ VOID NW_Print(LPCSTR lpFileName)
 VOID NW_Fini(VOID)
 {
 	NWL_ArgSetFree(NWLC->SmbiosTypes);
-	NWL_ArgSetFree(NWLC->PciClasses);
+	NWL_ArgSetFree(NWLC->PciFilters);
 	if (NWLC->NwRsdp)
 		free(NWLC->NwRsdp);
 	if (NWLC->NwRsdt)

--- a/libnw/libnw.h
+++ b/libnw/libnw.h
@@ -73,7 +73,7 @@ typedef struct _NWLIB_CONTEXT
 	LPCSTR DevTreeFilter;
 	DWORD AcpiTable;
 	PNWL_ARG_SET SmbiosTypes;
-	PNWL_ARG_SET PciClasses;
+	PNWL_ARG_SET PciFilters;
 	LPSTR DiskPath;
 	LPSTR NetGuid;
 	LPCSTR ProductPolicy;
@@ -253,7 +253,7 @@ typedef struct _NWLIB_NET_TRAFFIC
 } NWLIB_NET_TRAFFIC;
 LIBNW_API VOID NWL_GetNetTraffic(NWLIB_NET_TRAFFIC* info, BOOL bit);
 
-LIBNW_API PNODE NWL_EnumPci(PNODE pNode, PNWL_ARG_SET pciClasses);
+LIBNW_API PNODE NWL_EnumPci(PNODE pNode, PNWL_ARG_SET pciFilters);
 
 typedef struct _NWLIB_CUR_DISPLAY
 {

--- a/nwinfo.c
+++ b/nwinfo.c
@@ -143,9 +143,10 @@ static void nwinfo_help(void)
 		"                   'NOCSMI' and 'CSMIRAID'.\n"
 		"  --display[=FILE] Print EDID info.\n"
 		"    FILE           Specify the file name of the EDID dump.\n"
-		"  --pci[=CLASS,..] Print PCI info.\n"
-		"                   CLASS specifies the class codes of PCI devices,\n"
-		"                   e.g. '0c05' or '03,0c05'.\n"
+		"  --pci[=FILTER,..] Print PCI info.\n"
+		"                   FILTER specifies PCI class codes or vendor IDs,\n"
+		"                   e.g. '0c05', '03,0c05', 'v8086',\n"
+		"                   or 'v8086,03'.\n"
 		"  --usb            Print USB info.\n"
 		"  --spd[=FILE]     Print DIMM SPD info.\n"
 		"                   WARNING: This option may damage the hardware.\n"
@@ -275,7 +276,7 @@ int main(int argc, char* argv[])
 	nwContext.AcpiTable = 0;
 	nwContext.SmbiosTypes = NULL;
 	nwContext.DiskPath = NULL;
-	nwContext.PciClasses = NULL;
+	nwContext.PciFilters = NULL;
 
 	struct optparse options;
 	optparse_init(&options, argv);
@@ -420,7 +421,7 @@ int main(int argc, char* argv[])
 			nwContext.EdidInfo = TRUE;
 			break;
 		case NW_OPT_PCI:
-			nwinfo_parse_arg_set(options.optarg, &nwContext.PciClasses, TRUE);
+			nwinfo_parse_arg_set(options.optarg, &nwContext.PciFilters, TRUE);
 			nwContext.PciInfo = TRUE;
 			break;
 		case NW_OPT_USB:


### PR DESCRIPTION
### Motivation
- Extend the `--pci` option to allow filtering by PCI vendor ID tokens (e.g. `v8086`) in addition to class codes and to support mixed combinations of vendor and class tokens.
- Reuse existing parsing helpers (`nwinfo_parse_arg_set`) and avoid introducing new structures as requested.

### Description
- Rename `NWLIB_CONTEXT::PciClasses` to `PciFilters` and update initialization/cleanup to use `PciFilters` instead of the old name.
- Update help text for `--pci` in `nwinfo.c` to document `FILTER` tokens such as class codes and vendor IDs (e.g. `v8086`, `03`, `0c05`, or combinations).
- Replace the old `MatchPciClass` with `MatchPciFilter` in `libnw/pci.c` to handle tokens prefixed with `v` (vendor IDs) and plain class code tokens, and implement combined matching logic (devices must match vendor tokens if any vendor filters are present, and must match class tokens if any class filters are present).
- Extract the vendor ID from device HWID strings by searching for `VEN_` while enumerating hardware IDs and pass it to `MatchPciFilter`; update `NWL_EnumPci` signature to accept the filter set and update callers to pass `PciFilters`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69758afc2fa0832fbcdc40f51757736d)

## Summary by Sourcery

Support PCI device filtering by both class codes and vendor IDs via the existing --pci argument.

New Features:
- Allow --pci to filter PCI devices by vendor ID tokens (e.g. v8086) in addition to class codes, including mixed vendor/class filters.

Enhancements:
- Rename the PCI filter context field from PciClasses to PciFilters and propagate the new name across the library API and callers.
- Update PCI enumeration logic to parse hardware IDs for VEN_ codes and apply combined vendor/class matching rules.
- Refresh --pci help text to describe the new FILTER syntax and example combinations of class and vendor filters.