### PR TITLE
Fix variadic formatting in libnw helpers

### DIFF
--- a/libnw/efivars.c
+++ b/libnw/efivars.c
@@ -175,8 +175,11 @@ AllocPrintf(LPCSTR _Printf_format_string_ format, ...)
 	int sz;
 	CHAR* buf = NULL;
 	va_list ap;
+	va_list ap_copy;
 	va_start(ap, format);
-	sz = _vscprintf(format, ap) + 1;
+	va_copy(ap_copy, ap);
+	sz = _vscprintf(format, ap_copy) + 1;
+	va_end(ap_copy);
 	if (sz <= 0)
 	{
 		va_end(ap);

--- a/libnw/node.c
+++ b/libnw/node.c
@@ -239,9 +239,12 @@ NWL_NodeAttrSetf(PNODE node, LPCSTR key, INT flags, LPCSTR _Printf_format_string
 	char* buf = NULL;
 	PNODE_ATT att = NULL;
 	va_list ap;
+	va_list ap_copy;
 
 	va_start(ap, format);
-	sz = _vscprintf(format, ap) + 1;
+	va_copy(ap_copy, ap);
+	sz = _vscprintf(format, ap_copy) + 1;
+	va_end(ap_copy);
 	if (sz <= 0)
 	{
 		va_end(ap);


### PR DESCRIPTION
### Motivation
- 修复在格式化函数中重复使用 `va_list` 导致的未定义行为，从而避免格式化输出错乱或潜在崩溃。

### Description
- In `NWL_NodeAttrSetf` (`libnw/node.c`) and `AllocPrintf` (`libnw/efivars.c`) duplicate the `va_list` with `va_copy` before calling `_vscprintf`, then `va_end` the copy so `vsnprintf` can safely consume the original `va_list` without undefined behavior.

### Testing
- Ran `git diff --check` and an `rg -n -C 2 "va_copy|_vscprintf|vsnprintf" libnw/node.c libnw/efivars.c` to verify the changes were applied and the pattern no longer misuses the `va_list`, both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff2cc1f64832fa0fe0f25115c03f1)

## Summary by Sourcery

Fix variadic formatting helpers to avoid undefined behavior when reusing va_list.

Bug Fixes:
- Prevent undefined behavior in AllocPrintf by copying the va_list before calling the sizing formatter.
- Prevent undefined behavior in NWL_NodeAttrSetf by duplicating and properly ending a va_list used for size calculation.