### PR TITLE
fix: the pawnio kernel driver copies user-supplied i... in pawnio.c

### DIFF
--- a/ioctl/pawnio.c
+++ b/ioctl/pawnio.c
@@ -67,6 +67,9 @@ int WR0_ExecPawn(struct wr0_drv_t* drv, struct pio_mod_t* mod, LPCSTR fn,
 	if (!mod->hd || mod->hd == INVALID_HANDLE_VALUE)
 		return -1;
 
+	if (in_size > (MAXDWORD - sizeof(PIO_EXEC_INPUT)) / sizeof(ULONG64))
+		return -1;
+
 	inBufSize = (DWORD)(sizeof(PIO_EXEC_INPUT) + in_size * sizeof(ULONG64));
 
 	inBuf = calloc(1, inBufSize);


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `ioctl/pawnio.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `ioctl/pawnio.c:79` |

**Description**: The PawnIO kernel driver copies user-supplied IOCTL input into a kernel buffer without validating the size parameter. The expression in_size * sizeof(ULONG64) can also integer-overflow if in_size is crafted to be very large, producing a small computed size that bypasses naive checks while the actual copy still overflows the destination buffer. This is a classic kernel IOCTL exploitation pattern.

## Changes
- `ioctl/pawnio.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

## Summary by Sourcery

Bug Fixes:
- Prevent integer overflow and oversized allocations by validating the IOCTL input element count before computing the kernel input buffer size.